### PR TITLE
Add basic support for Host Metrics

### DIFF
--- a/manifests/hostmetrics.pp
+++ b/manifests/hostmetrics.pp
@@ -1,0 +1,33 @@
+# configure the agent to send 'SystemStats' such as CPU and memory usage and so on
+# see: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Installed_Sources
+define sumo::hostmetrics (
+  $source_name = 'Host_Metrics',
+  $description = undef,
+  $ensure      = 'present',
+  $category    = undef, # prefer OS/Linux/Metrics
+  $metrics     = ['CPU_User','CPU_Sys','Mem_Used'],
+  $interval    = 10000, # ten seconds
+) {
+  validate_string($source_name)
+  validate_array($metrics)
+  validate_numeric($interval)
+
+  $_source_name = downcase(regsubst($source_name, '[^a-zA-Z0-9]', ''))
+  $_config_path = "${::sumo::sources_path}/${_source_name}.json"
+  $_file_ensure = $ensure ? {
+    'present' => 'file',
+    'absent'  => 'absent',
+  }
+
+  file { $_config_path:
+    ensure  => $_file_ensure,
+    content => template("${module_name}/hostmetrics.json.erb"),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    seluser => 'system_u',
+    selrole => 'object_r',
+    seltype => 'etc_t',
+    notify  => Service[$::sumo::service_name],
+  }
+}

--- a/templates/hostmetrics.json.erb
+++ b/templates/hostmetrics.json.erb
@@ -5,7 +5,7 @@
     "description": "<%= @description %>",
     "sourceType": "SystemStats",
     "category": "<%= @category %>",
-    "metrics": "<%= @metrics %>"
+    "metrics": <%= @metrics %>,
     "interval": <%= @interval %>
   }
 }

--- a/templates/hostmetrics.json.erb
+++ b/templates/hostmetrics.json.erb
@@ -1,0 +1,11 @@
+{
+  "api.version": "v1",
+  "source": {
+    "name": "<%= @source_name %>",
+    "description": "<%= @description %>",
+    "sourceType": "SystemStats",
+    "category": "<%= @category %>",
+    "metrics": "<%= @metrics %>"
+    "interval": <%= @interval %>
+  }
+}


### PR DESCRIPTION
SumoLogic Host Metrics is a system for measuring and analysing 'continuous' things such as memory usage, CPU utilization and so on (rather than discrete things like log entries).

Essentially the collector agent takes periodic samples and sends the data off so that it can be recorded, charted, alerted upon and all that good stuff.
 
The documentation is here: https://help.sumologic.com/Send_Data/Data_Types/Host_Metrics