### PR TITLE
add support for DockerStats and DockerLogs sources

### DIFF
--- a/manifests/localfile.pp
+++ b/manifests/localfile.pp
@@ -1,22 +1,31 @@
 # install local file source
 # see: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources#Common_parameters_for_all_Source_types
 define sumo::localfile (
+  # common args
   $source_name          = $name,
+  $source_type          = 'LocalFile',
   $description          = undef,
   $ensure               = 'present',
   $category             = undef,
-  $path_expression      = undef,
   $auto_date_parsing    = true,
   $auto_line_matching   = true,
   $multiline_processing = true,
   $force_timezone       = false,
   $timezone             = $::sumo::timezone,
   $filters              = [],
+
+  # LocalFile args
+  $path_expression      = undef,
+
+  # DockerLog, DockerStats
+  $uri                  = 'unix:///var/run/docker.sock',
 ) {
   validate_string($source_name)
+  validate_string($source_type)
   validate_string($category)
   validate_string($path_expression)
   validate_array($filters)
+  validate_string($uri)
 
   $filters.each |$filter| {
     validate_hash($filter)

--- a/templates/localfile.json.erb
+++ b/templates/localfile.json.erb
@@ -3,14 +3,18 @@
   "source": {
     "name": "<%= @source_name %>",
     "description": "<%= @description %>",
-    "sourceType": "LocalFile",
+    "sourceType": "<%= @source_type %>",
     "automaticDateParsing": <%= @auto_date_parsing %>,
     "multilineProcessingEnabled": <%= @multiline_processing %>,
     "useAutolineMatching": <%= @auto_line_matching %>,
     "forceTimeZone": <%= @force_timezone %>,
     "timeZone": "<%= @timezone %>",
-    "category": "<%= @category %>",
-    "pathExpression": "<%= @path_expression %>"
+    "category": "<%= @category %>"
+
+    <% if @source_type == 'LocalFile' -%>,
+      "pathExpression": "<%= @path_expression %>",
+    <% end -%>
+
     <% if @filters != [] -%>, "filters": [
       <% @filters.each_with_index do |filter, i| %> {
         "name": "<%= filter['name'] %>",
@@ -20,6 +24,23 @@
         <% if filter['transparentForwarding'] -%>"transparentForwarding": "<%= filter['transparentForwarding'] %>",<% end -%>
       }<%= ',' if i < (@filters.size - 1) %><% end -%>
     ] <% end -%>
+
+    <% if @source_type == 'DockerLog' -%>,
+      "uri": "<%= @uri %>",
+      "allContainers": true,
+      "collectEvents": true,
+      "specifiedContainers": [],
+      "certPath": ""
+    <% end -%>
+
+    <% if @source_type == 'DockerStats' -%>,
+      "uri": "<%= @uri %>",
+      "allContainers": true,
+      "specifiedContainers": [],
+      "cutoffTimestamp": 0,
+      "certPath": "",
+      "pollInterval": 60000
+    <% end -%>
   }
 }
 


### PR DESCRIPTION
DockerLogs and DockerStats sources have a few different configuration options. See https://help.sumologic.com/03Send-Data/Sources/03Use-JSON-to-Configure-Sources/JSON-Parameters-for-Installed-Sources#Docker_Log_Source